### PR TITLE
Cartes plus grandes

### DIFF
--- a/components/home/previews/base-maps-preview/index.js
+++ b/components/home/previews/base-maps-preview/index.js
@@ -8,11 +8,11 @@ import Selector from './selector'
 
 class BaseMapsPreview extends React.Component {
   render() {
-    const {title, url, selectedTheme, selectedLanguage, themes, languages, onSelectTheme, onSelectLanguage, reverse, children} = this.props
+    const {title, url, selectedTheme, selectedLanguage, themes, languages, onSelectTheme, onSelectLanguage, children} = this.props
 
     return (
       <Section title={title}>
-        <div className={`container ${reverse ? 'reverse' : ''}`}>
+        <div className='container'>
 
           <div className='form'>
             <h4>Choisir le thème</h4>
@@ -38,24 +38,19 @@ class BaseMapsPreview extends React.Component {
         <style jsx>{`
           .container {
             display: flex;
-            justify-content: space-between;
-            align-items: center;
+            flex-direction: column;
           }
 
           .map {
-            width: 50%;
+            width: 100%;
           }
 
           .preview {
             height: 70vh;
           }
 
-          .reverse {
-            flex-direction: row-reverse;
-          }
-
           .form {
-            min-width: 320px;
+            margin: 1em 0;
           }
 
           @media (max-width: 680px) {
@@ -94,16 +89,13 @@ BaseMapsPreview.propTypes = {
   selectedLanguage: PropTypes.string,
   onSelectLanguage: PropTypes.func,
 
-  reverse: PropTypes.bool,
-
   children: PropTypes.node.isRequired
 }
 
 BaseMapsPreview.defaultProps = {
   languages: null,
   selectedLanguage: null,
-  onSelectLanguage: () => {},
-  reverse: false
+  onSelectLanguage: () => {}
 }
 
 export default BaseMapsPreview

--- a/components/home/previews/vector-preview/index.js
+++ b/components/home/previews/vector-preview/index.js
@@ -13,7 +13,7 @@ class VectorPreview extends React.Component {
 
     return (
       <Section title='Fond OpenMapTiles - vectoriel'>
-        <div className='container'>
+        <div>
           <div className='map'>
             <VectorTilesPreview style={url} />
           </div>
@@ -22,11 +22,6 @@ class VectorPreview extends React.Component {
           <TilesUrl url={url} />
         </div>
         <style jsx>{`
-          .container {
-            margin: 0 auto;
-            max-width: 600px;
-          }
-
           .map {
             height: 70vh;
           }


### PR DESCRIPTION
Les cartes occupent désormais tout l'espace disponible. Les boutons de sélection des styles se retrouvent en haut de la carte.


![capture d ecran 2018-07-09 a 16 38 11](https://user-images.githubusercontent.com/7040549/42457064-ba4e3798-8396-11e8-8335-d8bad7aa9594.png)
